### PR TITLE
Enable basic CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: main
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x, 13.x]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: yarn
+      - name: Run tests
+        run: yarn test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Script Container Transformer
 
+[![Actions Status][1]][2]
+
 This transformer allows for executing an arbitrary script to transform the Container in some custom way. It supports transformation of both iOS and Android Containers.
 
 ## Inputs
@@ -71,3 +73,6 @@ transformer.transform(
   }
 })
 ```
+
+[1]: https://github.com/electrode-io/ern-container-transformer-script/main/badge.svg
+[2]: https://github.com/electrode-io/ern-container-transformer-script/actions

--- a/test/ScriptTransformer-test.js
+++ b/test/ScriptTransformer-test.js
@@ -1,0 +1,8 @@
+import { equal } from 'assert'
+import ScriptTransformer from '../src/ScriptTransformer'
+
+describe('ScriptTransformer', () => {
+  it('should return name correctly', () => {
+    equal((new ScriptTransformer()).name, 'script')
+  })
+})


### PR DESCRIPTION
This adds a very basic test, so that the (already existing) `yarn test` script does not fail anymore.

Also adds a basic GitHub Actions config running the tests from now on for all pull requests using the LTS and current versions of [Node.js](https://nodejs.org/en/) (at the moment 12 & 13).